### PR TITLE
Issue# App-1003:Native APP login displays error when e-mail has uppercase lettering

### DIFF
--- a/CJStringValidator/NSString+CJStringValidator.m
+++ b/CJStringValidator/NSString+CJStringValidator.m
@@ -14,7 +14,7 @@
 }
 
 - (BOOL)isEmail {
-    NSString *regex = @"[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})";
+    NSString *regex = @"[_a-zA-Z0-9-]+(\.[_a-zA-Z0-9-]+)*@[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*(\.[a-z]{2,4})";
     NSPredicate *regExPredicate = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", regex];
     
     return [regExPredicate evaluateWithObject:self];


### PR DESCRIPTION
https://themelt.atlassian.net/browse/app-1003
Fixed Regex to allow for uppercase as first character of email